### PR TITLE
Attempt to fix error in continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
 script:
   - mkdir build
   - cd build
-  - cmake ..
+  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/install ..
   - make
   - make install
   - cd -


### PR DESCRIPTION
Attempt to fix error in continuous integration due to the fact that make install in /usr/local requires administrator privileges on linux.